### PR TITLE
Enable migration to/from :symmetric encryption

### DIFF
--- a/lib/strongbox/lock.rb
+++ b/lib/strongbox/lock.rb
@@ -51,6 +51,8 @@ module Strongbox
           @instance[@symmetric_iv] = encrypted_iv
         else
           ciphertext = public_key.public_encrypt(plaintext,@padding)
+          @instance[@symmetric_key] = nil if @instance[@symmetric_key]
+          @instance[@symmetric_iv] = nil if @instance[@symmetric_iv]
         end
         ciphertext =  Base64.encode64(ciphertext) if @base64
         @instance[@name] = ciphertext
@@ -75,7 +77,7 @@ module Strongbox
       if ciphertext
         ciphertext = Base64.decode64(ciphertext) if @base64
         private_key = get_rsa_key(@private_key,password)
-        if @symmetric == :always
+        if symmetric_available?
           random_key = @instance[@symmetric_key]
           random_iv = @instance[@symmetric_iv]
           if @base64
@@ -132,6 +134,11 @@ module Strongbox
   end
 
 private
+
+    def symmetric_available?
+      @instance[@symmetric_key] && @instance[@symmetric_iv]
+    end
+
     def get_rsa_key(key,password = '')
       return key if key.is_a?(OpenSSL::PKey::RSA)
       if key !~ /^-+BEGIN .* KEY-+$/


### PR DESCRIPTION
Hi Spike,

Wondered if you'd be interested in this patch.  It allows decryption of symmetrically encrypted columns even when `:symmetric => :never`, and decryption of asymmetrically-encrypted columns even when `:symmetric => :always`, which allows developers to change their implementation against a live database without having to get their hands dirty.

I understand that it muddies the semantics of `:always` and `:never` for the purposes of decryption, but it does uphold the guarantee that any subsequent encryption will follow the expected semantics (and tellingly didn't require modification of any existing tests to implement).  The patch enables behavior that previously would've resulted in somewhat mysterious errors, e.g. this trace from a decrypt of a model that was switched to symmetric encryption:

```
/usr/ruby1.9.2/lib/ruby/1.9.1/base64.rb:58:in `decode64'
.bundle/gems/ruby/1.9.1/gems/strongbox-0.4.6/lib/strongbox/lock.rb:82:in `decrypt'
```

Perhaps a flag (maybe `:enable_migration`) to allow the developer to opt into the modified semantics would be a good addition if a change like this makes you nervous, or perhaps that's too much.

Or perhaps you just want to keep it simple and not go there at all.  Anyway, great plugin.

Thanks,
-john
