### PR TITLE
Handle Keys When They Are a Pathname

### DIFF
--- a/lib/strongbox/lock.rb
+++ b/lib/strongbox/lock.rb
@@ -143,7 +143,9 @@ private
 
       return key if key.is_a?(OpenSSL::PKey::RSA)
 
-      if key !~ /^-+BEGIN .* KEY-+$/
+      if key.respond_to?(:read)
+        key = key.read
+      elsif key !~ /^-+BEGIN .* KEY-+$/
         key = File.read(key)
       end
       return OpenSSL::PKey::RSA.new(key,password)


### PR DESCRIPTION
It's not uncommon to see Pathnames in a Rails applications these days. They provide a better API for paths on the file system, and are generated with `Rails.root` (e.g. `Rails.root.join('public/my_file.txt')`). This change ensures they're handled correctly with Ruby beyond 1.8.7 as Pathname does not respond to `#=~`.
