### PR TITLE
Lock down versions to some version of a workable gemspec and fix rdoc

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ Bundler::GemHelper.install_tasks
 
 require 'rake'
 require 'rake/testtask'
-require 'rake/rdoctask'
+require 'rdoc/task'
 
 $LOAD_PATH << File.join(File.dirname(__FILE__), 'lib')
 require 'strongbox'

--- a/strongbox.gemspec
+++ b/strongbox.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |s|
   s.files = `git ls-files`.split("\n")
   s.test_files = `git ls-files -- test/*`.split("\n")
   s.add_runtime_dependency 'activerecord'
-  s.add_development_dependency 'thoughtbot-shoulda'
-  s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'thoughtbot-shoulda', '>= 2.9.0'
+  s.add_development_dependency 'sqlite3', '~> 1.3.7'
+  s.add_development_dependency 'rake', '>= 10.0.0'
+  s.add_development_dependency 'rdoc', '~> 2.4.0'
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,12 +2,10 @@ ROOT       = File.join(File.dirname(__FILE__), '..')
 RAILS_ROOT = ROOT
 $LOAD_PATH << File.join(ROOT, 'lib')
 
-require 'rubygems'
 require 'test/unit'
 require 'sqlite3'
 require 'active_record'
 require 'logger'
-gem 'thoughtbot-shoulda', ">= 2.9.0"
 require 'shoulda'
 begin require 'redgreen'; rescue LoadError; end
 


### PR DESCRIPTION
- Ran tests, they pass
- Was able to install suite with bundler as opposed to dependency hell
- Generated RDoc documentation without a problem
- Remove shoulda gem version specification in test file to gemspec
- Remove requirement of rubygems RE: https://gist.github.com/54177
