### PR TITLE
Actually assert in validation helper functions and minor clean up of tests

### DIFF
--- a/test/strongbox_multiply_test.rb
+++ b/test/strongbox_multiply_test.rb
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 require 'test/test_helper'
 
-class StrongboxMultiPlyTest < Test::Unit::TestCase
+class StrongboxMultiplyTest < Test::Unit::TestCase
   context 'A Class with two secured fields' do
     setup do
       @password = 'boost facile'

--- a/test/strongbox_test.rb
+++ b/test/strongbox_test.rb
@@ -46,7 +46,7 @@ class StrongboxTest < Test::Unit::TestCase
          end
        end
 
-       should 'impliment to_json' do
+       should 'implement to_json' do
         assert_nothing_raised do
           @dummy.secret.to_json
         end
@@ -156,11 +156,11 @@ class StrongboxTest < Test::Unit::TestCase
   end
 
   context 'when a private key is not provided' do
-     setup do
+    setup do
       @password = 'boost facile'
       rebuild_class(:public_key => File.join(FIXTURES_DIR,'keypair.pem'))
       @dummy = Dummy.new(:secret => 'Shhhh')
-     end
+    end
 
     should 'raise on decrypt with a password' do
       assert_raises(Strongbox::StrongboxError) do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -55,12 +55,12 @@ end
 
 def assert_has_errors_on(model,attribute)
   # Rails 2.X && Rails 3.X
-  !model.errors[attribute].empty?
+  assert !model.errors[attribute].empty?
 end
 
 def assert_does_not_have_errors_on(model,attribute)
   # Rails 2.X                     Rails 3.X
-  model.errors[attribute].nil? || model.errors[attribute].empty?
+  assert model.errors[attribute].nil? || model.errors[attribute].empty?
 end
 
 def generate_key_pair(password = nil,size = 2048)

--- a/test/validations_test.rb
+++ b/test/validations_test.rb
@@ -26,7 +26,6 @@ class ValidationsTest < Test::Unit::TestCase
     
     context 'using validates_length_of' do
       setup do
-        rebuild_class(:key_pair => File.join(FIXTURES_DIR,'keypair.pem'))
         Dummy.send(:validates_length_of,
                    :secret,
                    :in => 5..10,
@@ -64,7 +63,6 @@ class ValidationsTest < Test::Unit::TestCase
     if defined?(ActiveModel::Validations)  # Rails 3
       context 'using validates for length' do
         setup do
-          rebuild_class(:key_pair => File.join(FIXTURES_DIR,'keypair.pem'))
           Dummy.send(:validates,
                      :secret,
                      :length => {:minimum => 4, :maximum => 16})


### PR DESCRIPTION
Noticed that the two methods in the test_helper weren't actually asserting anything. This PR fixes that. I also removed 2 unnecessary resets of the model (or something similar to that) and some other spelling/grammar related minor stuff.
