### PR TITLE
Fix to_json

### DIFF
--- a/lib/strongbox/lock.rb
+++ b/lib/strongbox/lock.rb
@@ -122,6 +122,10 @@ module Strongbox
       to_s
     end
 
+    def as_json(options = nil)
+      to_s
+    end
+
     # Needed for validations
     def blank?
       @raw_content.blank? and @instance[@name].blank?


### PR DESCRIPTION
Still experiencing this issue in v.0.7.2: https://github.com/spikex/strongbox/issues/11

Adding the `as_json` method and having it return `to_s` solves the problem and prevents the `SystemStackError - stack level too deep` error.